### PR TITLE
Split filter parent class

### DIFF
--- a/examples/evaluation_run/clean.sh
+++ b/examples/evaluation_run/clean.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+rm -r conditioned_filters/ predictions/ report/

--- a/src/franc/evaluation/__init__.py
+++ b/src/franc/evaluation/__init__.py
@@ -20,6 +20,7 @@ from .evaluation import (
     measure_runtime,
 )
 from .report_generation import ReportElement
+from .filter_interface import FilterInterface, make_2d_array, handle_from_dict
 
 __all__ = [
     "rms",
@@ -39,4 +40,7 @@ __all__ = [
     "residual_amplitude_ratio",
     "measure_runtime",
     "ReportElement",
+    "FilterInterface",
+    "make_2d_array",
+    "handle_from_dict",
 ]

--- a/src/franc/evaluation/evaluation.py
+++ b/src/franc/evaluation/evaluation.py
@@ -163,19 +163,19 @@ class TestDataGenerator:
 def measure_runtime(
     filter_classes: Sequence[FilterBase],
     n_samples: int = int(1e4),
+    n_channel: int = 1,
     n_filter: int = 128,
     idx_target: int = 0,
-    n_channel: int = 1,
-    additional_filter_settings: Sequence[dict] | None = None,
+    additional_filter_settings: Sequence[dict[str, Any]] | None = None,
     repititions: int = 1,
 ) -> tuple[Sequence, Sequence]:
     """Measure the runtime of filers for a specific scenario
     Be aware that this gives no feedback upon how much multithreading is used!
 
     :param n_samples: Length of the test data
+    :param n_channel: Number of witness sensor channels
     :param n_filter: Length of the FIR filters / input block size
     :param idx_target: Position of the prediction
-    :param n_channel: Number of witness sensor channels
     :param additional_filter_settings: optional settings passed to the filters
     :param repititions: how manu repititions to perform during the timing measurement
 
@@ -194,7 +194,7 @@ def measure_runtime(
 
     def time_filter(filter_class, args):
         """wrapper function to make closures work correctly"""
-        filt = filter_class(n_filter, idx_target, n_channel, **args)
+        filt = filter_class(n_channel, n_filter, idx_target, **args)
         t_cond = timeit(lambda: filt.condition(witness, target), number=repititions)
         t_pred = timeit(lambda: filt.apply(witness, target), number=repititions)
         return t_cond / repititions, t_pred / repititions

--- a/src/franc/evaluation/evaluation.py
+++ b/src/franc/evaluation/evaluation.py
@@ -426,14 +426,12 @@ class EvaluationRun:  # pylint: disable=too-many-instance-attributes
         report_sections = []
 
         # identify changed values
-        print(results)
         for filter_method, configurations in results:
             parameter_values: dict[str, Any] = {}
             parameterset_hash = ""
 
             for conf, _, _, _, configuration_hash in configurations:
                 parameterset_hash += configuration_hash
-                print(conf)
                 for parameter, value in conf.items():
                     if parameter not in parameter_values:
                         parameter_values[parameter] = set()

--- a/src/franc/evaluation/filter_interface.py
+++ b/src/franc/evaluation/filter_interface.py
@@ -1,0 +1,355 @@
+"""Shared functionality and interface for all filtering techniques"""
+
+from typing import TypeVar, Any, overload
+from collections.abc import Sequence, Callable
+import abc
+from dataclasses import dataclass, asdict, fields
+import warnings
+import inspect
+import functools
+from pathlib import Path
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ..common import hash_function, hash_object_list
+
+# create a type variable that can be any instance of a Filter subclass
+FilterTypeT = TypeVar("FilterTypeT", bound="FilterInterface")
+
+
+def make_2d_array(A: Sequence | Sequence[Sequence] | NDArray) -> NDArray:
+    """add a dimension to 1D arrays and leave 2D arrays as they are
+    This is intended to allow 1D array input for single channel application
+
+    :param A: input array
+
+    :return: extended array
+
+    :raises: ValueError if the input shape is not compatible
+
+    >>> make_2d_array([1, 2])
+    array([[1, 2]])
+
+    >>> make_2d_array([[1, 2], [3, 4]])
+    array([[1, 2],
+           [3, 4]])
+
+    """
+    A_npy = np.array(A)
+    if len(A_npy.shape) == 1:
+        return np.array([A_npy])
+    if len(A_npy.shape) == 2:
+        return A_npy
+    raise ValueError("Input must be 1D or 2D array")
+
+
+def handle_from_dict(init_func: Callable):
+    """A decorator for the init functions of classes derived from FitlerInterface
+
+    If the _from_dict keyword argument is passed, the __init__() function is ignored
+    and the class is initialized based on the passed dictionary.
+    Otherwise, the constructor is called the usual way.
+    """
+    from_dict_key = "_from_dict"
+
+    @functools.wraps(init_func)
+    def wrapper(self, *args, **kwargs):
+        if from_dict_key in kwargs and kwargs[from_dict_key] is not None:
+            from_dict = kwargs[from_dict_key]
+            for key in from_dict:
+                setattr(self, key, from_dict[key])
+        else:
+            # save init parameters
+            self.init_parameters = list(args) + [kwargs[key] for key in sorted(kwargs)]
+
+            # calculate method hash
+            hashes = self.file_hash()  # pylint: disable=[protected-access]
+            hashes += FilterInterface.file_hash()  # pylint: disable=[protected-access]
+            hashes += hash_object_list(self.init_parameters)
+            self.method_hash_value = hash_function(hashes)
+
+            init_func(self, *args, **kwargs)
+
+    return wrapper
+
+
+@dataclass
+class FilterInterface(abc.ABC):
+    """common interface definition for Filter implementations
+
+    :param n_channel: Number of witness sensor channels
+    """
+
+    # properties listed here will be export in serialized dumps
+    # NOTE: all properties here must be serializable by np.savez()
+    #       with allow_pickle=False. This does exclude None!
+
+    # It set to True, a target series is required for this filter type to apply()
+    requires_apply_target: bool
+
+    n_channel: int
+    method_hash_value: bytes
+    supports_multi_sequence = True
+    filter_name = "FilterInterface"  # must be implemented in children
+    default_args = [None]
+
+    def __init__(self, n_channel: int, _from_dict=None):
+        del _from_dict  # make as ignored, it is used by the handle_from_dict decorator
+        self.n_channel = n_channel
+
+        if self.__class__ is FilterInterface:
+            warnings.warn("Instantiating FilterInterface is not intended!")
+        else:
+            assert hasattr(
+                self, "filter_name"
+            ), "BaseFilter childs must declare their name"
+
+        # this can be set to false after the super().__init__() statement in child
+        self.requires_apply_target = True
+
+    @staticmethod
+    def supports_saving_loading() -> bool:
+        """Indicates whether saving and loading is supported
+        Due to the way dataclasses work with inheritance, class values with default values don't work in the parent dataclass.
+        Thus, this is a function
+        """
+        return True
+
+    def condition(
+        self,
+        witness: Sequence | Sequence[Sequence] | NDArray,
+        target: Sequence | NDArray,
+    ):
+        """Use an input dataset to condition the filter
+
+        :param witness: Witness sensor data
+        :param target: Target sensor data
+        """
+        return self.condition_multi_sequence([witness], [target])
+
+    @abc.abstractmethod
+    def condition_multi_sequence(
+        self,
+        witness: Sequence | Sequence[Sequence] | NDArray,
+        target: Sequence | NDArray,
+    ) -> Any:
+        """Similar to condition(), but expects multiple sequences"""
+
+    def apply(
+        self,
+        witness: Sequence | NDArray,
+        target: Sequence | NDArray | None = None,
+        pad: bool = True,
+        update_state: bool = False,
+    ) -> NDArray:
+        """Apply the filter to input data
+
+        :param witness: Witness sensor data (1D or 2D array)
+        :param target: Target sensor data (1D array)
+        :param pad: if True, apply padding zeros so that the length matches the target signal
+        :param update_state: if True, the filter state will be changed. If false, the filter state will remain
+
+        :return: prediction
+        """
+        if target is None:
+            return self.apply_multi_sequence([witness], None, pad, update_state)[0]
+        return self.apply_multi_sequence([witness], [target], pad, update_state)[0]
+
+    @abc.abstractmethod
+    def apply_multi_sequence(
+        self,
+        witness: Sequence | NDArray,
+        target: Sequence | NDArray | None,
+        pad: bool = True,
+        update_state: bool = False,
+    ) -> Sequence[NDArray]:
+        """Apply the filter to input data
+
+        Similar to apply() but expects multiple sequences.
+        """
+
+    def check_data_dimensions(
+        self,
+        witness: Sequence | NDArray,
+        target: Sequence | NDArray | None = None,
+    ) -> tuple[NDArray, NDArray]:
+        """Check the dimensions of the provided input data and apply make_2d_array()
+
+        :param witness: Witness sensor data
+        :param target: Target sensor data
+
+        :return: data as (target, witness)
+
+        :raises: AssertionError
+        """
+        target_npy = np.array(target)
+        witness_npy = make_2d_array(witness)
+        assert (
+            witness_npy.shape[0] == self.n_channel
+        ), "witness data shape does not match configured channel count"
+
+        if self.requires_apply_target:
+            assert (
+                target is None or target_npy.shape[0] == witness_npy.shape[1]
+            ), "Missmatch between target and witness data shapes"
+
+        return witness_npy, target_npy
+
+    # overloads to simplify type handling of return values
+    @overload
+    def check_data_dimensions_multi_sequence(
+        self,
+        witness: Sequence | NDArray,
+        target: None,
+    ) -> tuple[list[NDArray], None]: ...
+
+    @overload
+    def check_data_dimensions_multi_sequence(
+        self,
+        witness: Sequence | NDArray,
+        target: Sequence | NDArray,
+    ) -> tuple[list[NDArray], list[NDArray]]: ...
+
+    def check_data_dimensions_multi_sequence(
+        self,
+        witness: Sequence | NDArray,
+        target: Sequence | NDArray | None = None,
+    ) -> tuple[list[NDArray], list[NDArray] | None]:
+        """Check the dimensions of the provided input data and apply make_2d_array()
+
+        :param witness: Witness sensor data
+        :param target: Target sensor data
+
+        :return: data as (target, witness)
+
+        :raises: AssertionError
+        """
+        witness_npy = [make_2d_array(w) for w in witness]
+        for w in witness_npy:
+            assert (
+                w.shape[0] == self.n_channel
+            ), "witness data shape does not match configured channel count"
+
+        if target is not None:
+            assert len(witness) == len(target)
+            target_npy = [np.array(t) for t in target]
+
+            for w, t in zip(witness_npy, target_npy):
+                assert (
+                    w.shape[1] == t.shape[0]
+                ), "Missmatch between target and witness data shapes"
+        else:
+            target_npy = None
+
+        if self.requires_apply_target:
+            assert (
+                target is not None
+            ), "This filter requires a target signal to be applied"
+
+        return witness_npy, target_npy
+
+    def as_dict(self) -> dict[str, Any]:
+        """Returns a dictionary that represents the state of this filter."""
+        if not self.supports_saving_loading():
+            raise NotImplementedError(
+                "Saving and loading is not supported for this filter type."
+            )
+
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls: type[FilterTypeT], input_dict: dict[str, Any]) -> FilterTypeT:
+        """Create a filter instance from a dictionary that was created from as_dict()"""
+        # check that the dict contains all relevant keys and eliminate any extra keys
+        if not cls.supports_saving_loading():
+            raise NotImplementedError(
+                "Saving and loading is not supported for this filter type."
+            )
+
+        try:
+            clean_dict = {key.name: input_dict[key.name] for key in fields(cls)}
+        except Exception as e:
+            raise ValueError("Non-compatible dictionary, could not load filter.") from e
+
+        if not hasattr(cls, "filter_name"):
+            raise ValueError("From_dict cannot be used on an unnamed filter class.")
+        if cls.filter_name != clean_dict["filter_name"]:  # pylint: disable=no-member
+            raise ValueError(
+                f'Loading a {clean_dict["filter_name"]} as {cls.filter_name} is not possible.'  # pylint: disable=no-member
+            )
+
+        # passing the _from_dict value should make all other values be relevant
+        # They are set to the incompatible None type to potentially fail early in case of an error
+        return cls(*cls.default_args, _from_dict=clean_dict)  # type: ignore[arg-type, misc]
+
+    @classmethod
+    def make_filename(cls: type[FilterTypeT], filename: str | Path):
+        """Append the file type of save files for this class to the given filename, if it is not already present"""
+        if isinstance(filename, Path):
+            filename = str(filename)
+        ending = "." + cls.filter_name + ".npz"  # pylint: disable=no-member
+        if not filename.endswith(ending):
+            filename += ending
+        return filename
+
+    def save(self, filename: str | Path, warn_incompatible: bool = False):
+        """Save the filter state as a numpy file
+
+        The given filename will be autocompleted with a  ".<filter_name>.npz"
+        filename extension, unless a matching extension is detected.
+
+        warn_incompatible: set to True to warn for object types might not
+                           compatible with np.save(allow_pickle=False) during development
+        """
+        serialization_data = self.as_dict()
+        filename = self.make_filename(filename)
+
+        # this is intended to quickly identify problematic values when developing a new filter
+        if warn_incompatible:
+            for k, v in serialization_data.items():
+                if type(v) not in {str, int, float, np.ndarray, bool}:
+                    print(
+                        f">> Potentially incompatible with numpy.save(pickle=False) {k}: {v}"
+                    )
+
+        # pickles are disable for security reasons
+        np.savez(filename, allow_pickle=False, **serialization_data)
+
+    @classmethod
+    def load(cls: type[FilterTypeT], filename) -> FilterTypeT:
+        """Load a filter state from the supplied filename.
+
+        The given filename will be autocompleted with a  ".<filter_name>.npz"
+        filename extension, unless a matching extension is detected.
+        """
+        if not cls.supports_saving_loading():
+            raise NotImplementedError(
+                "Saving and loading is not supported for this filter type."
+            )
+
+        filename = cls.make_filename(filename)
+
+        # pickles are disable for security reasons
+        filter_dict = dict(np.load(filename, allow_pickle=False))
+        return cls.from_dict(filter_dict)
+
+    @classmethod
+    def file_hash(cls: type[FilterTypeT]) -> bytes:
+        """Calculates a hash value based on the file in which this method was defined."""
+        with open(inspect.getfile(cls), "rb") as f:
+            script = f.read()
+        return hash_function(script)
+
+    @property
+    def method_hash(self) -> bytes:
+        """A hash of the method and parameters
+        NOTE: This is not a hash of the conditioned filter!
+        Thus, the same filter configuration applied to a different dataset will result in the same hash!
+        """
+        return self.method_hash_value
+
+    @property
+    def method_filename_part(self) -> str:
+        """string that can be used in a file name"""
+        return f"{self.filter_name}_{self.n_channel}_"

--- a/src/franc/evaluation/report_generation.py
+++ b/src/franc/evaluation/report_generation.py
@@ -193,8 +193,10 @@ postbreak=\mbox{{$\hookrightarrow$}\space},
             ["pdflatex", "-halt-on-error", fname.with_suffix(".tex").name],
             cwd=fname.parent,
             check=False,
+            capture_output=True,
         )
         if retval.returncode != 0:
+            print(retval.stdout, "\n\n", retval.stderr)
             raise RuntimeError("PDF generation with pdflatex failed.")
 
         return fname.with_suffix(".pdf")

--- a/src/franc/external/spicypy_wf.py
+++ b/src/franc/external/spicypy_wf.py
@@ -27,7 +27,7 @@ class SpicypyWienerFilter(FilterBase):
     >>> import franc as fnc
     >>> n_filter = 10
     >>> witness, target = fnc.evaluation.TestDataGenerator(0.1).generate(int(1e3))
-    >>> filt = fnc.external.SpicypyWienerFilter(n_filter, 0, 1)
+    >>> filt = fnc.external.SpicypyWienerFilter(1, n_filter, 0)
     >>> sp_filt = filt.condition(witness, target)
     >>> prediction = filt.apply(witness, target) # apply to training data
 
@@ -39,11 +39,11 @@ class SpicypyWienerFilter(FilterBase):
     @handle_from_dict
     def __init__(
         self,
+        n_channel: int,
         n_filter: int,
         idx_target: int,
-        n_channel: int = 1,
     ):
-        super().__init__(n_filter, idx_target, n_channel)
+        super().__init__(n_channel, n_filter, idx_target)
 
         self.conditioned = False
         self.filter_state: spicypy.signal.WienerFilter | None

--- a/src/franc/filtering/common.py
+++ b/src/franc/filtering/common.py
@@ -1,81 +1,12 @@
 """Shared functionality for all filtering techniques"""
 
-from typing import TypeVar, Any, overload
-from collections.abc import Sequence, Callable
-import abc
-from dataclasses import dataclass, asdict, fields
-import warnings
-import inspect
-import functools
-from pathlib import Path
+from dataclasses import dataclass
 
-import numpy as np
-from numpy.typing import NDArray
-
-from ..common import hash_function, hash_object_list
-
-# create a type variable that can be any instance of a Filter subclass
-FilterTypeT = TypeVar("FilterTypeT", bound="FilterBase")
-
-
-def make_2d_array(A: Sequence | Sequence[Sequence] | NDArray) -> NDArray:
-    """add a dimension to 1D arrays and leave 2D arrays as they are
-    This is intended to allow 1D array input for single channel application
-
-    :param A: input array
-
-    :return: extended array
-
-    :raises: ValueError if the input shape is not compatible
-
-    >>> make_2d_array([1, 2])
-    array([[1, 2]])
-
-    >>> make_2d_array([[1, 2], [3, 4]])
-    array([[1, 2],
-           [3, 4]])
-
-    """
-    A_npy = np.array(A)
-    if len(A_npy.shape) == 1:
-        return np.array([A_npy])
-    if len(A_npy.shape) == 2:
-        return A_npy
-    raise ValueError("Input must be 1D or 2D array")
-
-
-def handle_from_dict(init_func: Callable):
-    """A decorator for the init functions of classes derived from FilterBase
-
-    If the _from_dict keyword argument is passed, the __init__() function is ignored
-    and the class is initialized based on the passed dictionary.
-    Otherwise, the constructor is called the usual way.
-    """
-    from_dict_key = "_from_dict"
-
-    @functools.wraps(init_func)
-    def wrapper(self, *args, **kwargs):
-        if from_dict_key in kwargs and kwargs[from_dict_key] is not None:
-            from_dict = kwargs[from_dict_key]
-            for key in from_dict:
-                setattr(self, key, from_dict[key])
-        else:
-            # save init parameters
-            self.init_parameters = list(args) + [kwargs[key] for key in sorted(kwargs)]
-
-            # calculate method hash
-            hashes = self.file_hash()  # pylint: disable=[protected-access]
-            hashes += FilterBase.file_hash()  # pylint: disable=[protected-access]
-            hashes += hash_object_list(self.init_parameters)
-            self.method_hash_value = hash_function(hashes)
-
-            init_func(self, *args, **kwargs)
-
-    return wrapper
+from ..evaluation import FilterInterface, make_2d_array, handle_from_dict
 
 
 @dataclass
-class FilterBase(abc.ABC):
+class FilterBase(FilterInterface):
     """common interface definition for Filter implementations
 
     :param n_filter: Length of the FIR filter
@@ -84,23 +15,12 @@ class FilterBase(abc.ABC):
     :param n_channel: Number of witness sensor channels
     """
 
-    # properties listed here will be export in serialized dumps
-    # NOTE: all properties here must be serializable by np.savez()
-    #       with allow_pickle=False. This does exclude None!
-
-    # It set to True, a target series is required for this filter type to apply()
-    requires_apply_target: bool
-
     n_filter: int
-    n_channel: int
     idx_target: int
-    method_hash_value: bytes
-    supports_multi_sequence = True
-    filter_name = "FilterBase"  # must be implemented in children
+    default_args = [None, None, None]
 
     def __init__(self, n_channel: int, n_filter: int, idx_target: int, _from_dict=None):
-        del _from_dict  # make as ignored, it is used by the handle_from_dict decorator
-        self.n_channel = n_channel
+        super().__init__(n_channel, _from_dict=_from_dict)
         self.n_filter = n_filter
         self.idx_target = idx_target
 
@@ -110,258 +30,12 @@ class FilterBase(abc.ABC):
             self.idx_target >= 0 and self.idx_target < self.n_filter
         ), "idx_target must not be negative and smaller than n_filter"
 
-        if self.__class__ is FilterBase:
-            warnings.warn("Instantiating FilterBase is not intended!")
-        else:
-            assert hasattr(
-                self, "filter_name"
-            ), "BaseFilter childs must declare their name"
-
-        # this can be set to false after the super().__init__() statement in child
-        self.requires_apply_target = True
-
-    @staticmethod
-    def supports_saving_loading() -> bool:
-        """Indicates whether saving and loading is supported
-        Due to the way dataclasses work with inheritance, class values with default values don't work in the parent dataclass.
-        Thus, this is a function
-        """
-        return True
-
-    def condition(
-        self,
-        witness: Sequence | Sequence[Sequence] | NDArray,
-        target: Sequence | NDArray,
-    ):
-        """Use an input dataset to condition the filter
-
-        :param witness: Witness sensor data
-        :param target: Target sensor data
-        """
-        return self.condition_multi_sequence([witness], [target])
-
-    @abc.abstractmethod
-    def condition_multi_sequence(
-        self,
-        witness: Sequence | Sequence[Sequence] | NDArray,
-        target: Sequence | NDArray,
-    ) -> Any:
-        """Similar to condition(), but expects multiple sequences"""
-
-    def apply(
-        self,
-        witness: Sequence | NDArray,
-        target: Sequence | NDArray | None = None,
-        pad: bool = True,
-        update_state: bool = False,
-    ) -> NDArray:
-        """Apply the filter to input data
-
-        :param witness: Witness sensor data (1D or 2D array)
-        :param target: Target sensor data (1D array)
-        :param pad: if True, apply padding zeros so that the length matches the target signal
-        :param update_state: if True, the filter state will be changed. If false, the filter state will remain
-
-        :return: prediction
-        """
-        if target is None:
-            return self.apply_multi_sequence([witness], None, pad, update_state)[0]
-        return self.apply_multi_sequence([witness], [target], pad, update_state)[0]
-
-    @abc.abstractmethod
-    def apply_multi_sequence(
-        self,
-        witness: Sequence | NDArray,
-        target: Sequence | NDArray | None,
-        pad: bool = True,
-        update_state: bool = False,
-    ) -> Sequence[NDArray]:
-        """Apply the filter to input data
-
-        Similar to apply() but expects multiple sequences.
-        """
-
-    def check_data_dimensions(
-        self,
-        witness: Sequence | NDArray,
-        target: Sequence | NDArray | None = None,
-    ) -> tuple[NDArray, NDArray]:
-        """Check the dimensions of the provided input data and apply make_2d_array()
-
-        :param witness: Witness sensor data
-        :param target: Target sensor data
-
-        :return: data as (target, witness)
-
-        :raises: AssertionError
-        """
-        target_npy = np.array(target)
-        witness_npy = make_2d_array(witness)
-        assert (
-            witness_npy.shape[0] == self.n_channel
-        ), "witness data shape does not match configured channel count"
-
-        if self.requires_apply_target:
-            assert (
-                target is None or target_npy.shape[0] == witness_npy.shape[1]
-            ), "Missmatch between target and witness data shapes"
-
-        return witness_npy, target_npy
-
-    # overloads to simplify type handling of return values
-    @overload
-    def check_data_dimensions_multi_sequence(
-        self,
-        witness: Sequence | NDArray,
-        target: None,
-    ) -> tuple[list[NDArray], None]: ...
-
-    @overload
-    def check_data_dimensions_multi_sequence(
-        self,
-        witness: Sequence | NDArray,
-        target: Sequence | NDArray,
-    ) -> tuple[list[NDArray], list[NDArray]]: ...
-
-    def check_data_dimensions_multi_sequence(
-        self,
-        witness: Sequence | NDArray,
-        target: Sequence | NDArray | None = None,
-    ) -> tuple[list[NDArray], list[NDArray] | None]:
-        """Check the dimensions of the provided input data and apply make_2d_array()
-
-        :param witness: Witness sensor data
-        :param target: Target sensor data
-
-        :return: data as (target, witness)
-
-        :raises: AssertionError
-        """
-        witness_npy = [make_2d_array(w) for w in witness]
-        for w in witness_npy:
-            assert (
-                w.shape[0] == self.n_channel
-            ), "witness data shape does not match configured channel count"
-
-        if target is not None:
-            assert len(witness) == len(target)
-            target_npy = [np.array(t) for t in target]
-
-            for w, t in zip(witness_npy, target_npy):
-                assert (
-                    w.shape[1] == t.shape[0]
-                ), "Missmatch between target and witness data shapes"
-        else:
-            target_npy = None
-
-        if self.requires_apply_target:
-            assert (
-                target is not None
-            ), "This filter requires a target signal to be applied"
-
-        return witness_npy, target_npy
-
-    def as_dict(self) -> dict[str, Any]:
-        """Returns a dictionary that represents the state of this filter."""
-        if not self.supports_saving_loading():
-            raise NotImplementedError(
-                "Saving and loading is not supported for this filter type."
-            )
-
-        return asdict(self)
-
-    @classmethod
-    def from_dict(cls: type[FilterTypeT], input_dict: dict[str, Any]) -> FilterTypeT:
-        """Create a filter instance from a dictionary that was created from as_dict()"""
-        # check that the dict contains all relevant keys and eliminate any extra keys
-        if not cls.supports_saving_loading():
-            raise NotImplementedError(
-                "Saving and loading is not supported for this filter type."
-            )
-
-        try:
-            clean_dict = {key.name: input_dict[key.name] for key in fields(cls)}
-        except Exception as e:
-            raise ValueError("Non-compatible dictionary, could not load filter.") from e
-
-        if not hasattr(cls, "filter_name"):
-            raise ValueError("From_dict cannot be used on an unnamed filter class.")
-        if cls.filter_name != clean_dict["filter_name"]:  # pylint: disable=no-member
-            raise ValueError(
-                f'Loading a {clean_dict["filter_name"]} as {cls.filter_name} is not possible.'  # pylint: disable=no-member
-            )
-
-        # passing the _from_dict value should make all other values be relevant
-        # They are set to the incompatible None type to potentially fail early in case of an error
-        return cls(None, None, None, _from_dict=clean_dict)  # type: ignore[arg-type]
-
-    @classmethod
-    def make_filename(cls: type[FilterTypeT], filename: str | Path):
-        """Append the file type of save files for this class to the given filename, if it is not already present"""
-        if isinstance(filename, Path):
-            filename = str(filename)
-        ending = "." + cls.filter_name + ".npz"  # pylint: disable=no-member
-        if not filename.endswith(ending):
-            filename += ending
-        return filename
-
-    def save(self, filename: str | Path, warn_incompatible: bool = False):
-        """Save the filter state as a numpy file
-
-        The given filename will be autocompleted with a  ".<filter_name>.npz"
-        filename extension, unless a matching extension is detected.
-
-        warn_incompatible: set to True to warn for object types might not
-                           compatible with np.save(allow_pickle=False) during development
-        """
-        serialization_data = self.as_dict()
-        filename = self.make_filename(filename)
-
-        # this is intended to quickly identify problematic values when developing a new filter
-        if warn_incompatible:
-            for k, v in serialization_data.items():
-                if type(v) not in {str, int, float, np.ndarray, bool}:
-                    print(
-                        f">> Potentially incompatible with numpy.save(pickle=False) {k}: {v}"
-                    )
-
-        # pickles are disable for security reasons
-        np.savez(filename, allow_pickle=False, **serialization_data)
-
-    @classmethod
-    def load(cls: type[FilterTypeT], filename) -> FilterTypeT:
-        """Load a filter state from the supplied filename.
-
-        The given filename will be autocompleted with a  ".<filter_name>.npz"
-        filename extension, unless a matching extension is detected.
-        """
-        if not cls.supports_saving_loading():
-            raise NotImplementedError(
-                "Saving and loading is not supported for this filter type."
-            )
-
-        filename = cls.make_filename(filename)
-
-        # pickles are disable for security reasons
-        filter_dict = dict(np.load(filename, allow_pickle=False))
-        return cls.from_dict(filter_dict)
-
-    @classmethod
-    def file_hash(cls: type[FilterTypeT]) -> bytes:
-        """Calculates a hash value based on the file in which this method was defined."""
-        with open(inspect.getfile(cls), "rb") as f:
-            script = f.read()
-        return hash_function(script)
-
-    @property
-    def method_hash(self) -> bytes:
-        """A hash of the method and parameters
-        NOTE: This is not a hash of the conditioned filter!
-        Thus, the same filter configuration applied to a different dataset will result in the same hash!
-        """
-        return self.method_hash_value
-
     @property
     def method_filename_part(self) -> str:
         """string that can be used in a file name"""
         return f"{self.filter_name}_{self.n_filter}_{self.n_channel}_{self.idx_target}"
+
+
+# include make_2d_array and handle_from_dict so all objects that
+# are potentially required to create a compatible filter are in one place
+__all__ = ["FilterBase", "make_2d_array", "handle_from_dict"]

--- a/src/franc/filtering/common.py
+++ b/src/franc/filtering/common.py
@@ -1,4 +1,4 @@
-"""Shared functionality for all other modules"""
+"""Shared functionality for all filtering techniques"""
 
 from typing import TypeVar, Any, overload
 from collections.abc import Sequence, Callable
@@ -98,12 +98,10 @@ class FilterBase(abc.ABC):
     supports_multi_sequence = True
     filter_name = "FilterBase"  # must be implemented in children
 
-    def __init__(
-        self, n_filter: int, idx_target: int, n_channel: int = 1, _from_dict=None
-    ):
+    def __init__(self, n_channel: int, n_filter: int, idx_target: int, _from_dict=None):
         del _from_dict  # make as ignored, it is used by the handle_from_dict decorator
-        self.n_filter = n_filter
         self.n_channel = n_channel
+        self.n_filter = n_filter
         self.idx_target = idx_target
 
         assert self.n_filter > 0, "n_filter must be a positive integer"
@@ -293,7 +291,9 @@ class FilterBase(abc.ABC):
                 f'Loading a {clean_dict["filter_name"]} as {cls.filter_name} is not possible.'  # pylint: disable=no-member
             )
 
-        return cls(1, 0, _from_dict=clean_dict)
+        # passing the _from_dict value should make all other values be relevant
+        # They are set to the incompatible None type to potentially fail early in case of an error
+        return cls(None, None, None, _from_dict=clean_dict)  # type: ignore[arg-type]
 
     @classmethod
     def make_filename(cls: type[FilterTypeT], filename: str | Path):
@@ -322,7 +322,7 @@ class FilterBase(abc.ABC):
             for k, v in serialization_data.items():
                 if type(v) not in {str, int, float, np.ndarray, bool}:
                     print(
-                        f">>> Potentially incompatible with numpy.save(pickle=False) {k}: {v}"
+                        f">> Potentially incompatible with numpy.save(pickle=False) {k}: {v}"
                     )
 
         # pickles are disable for security reasons

--- a/src/franc/filtering/lms.py
+++ b/src/franc/filtering/lms.py
@@ -66,7 +66,7 @@ class LMSFilter(FilterBase):
     >>> import franc as fnc
     >>> n_filter = 128
     >>> witness, target = fnc.evaluation.TestDataGenerator(0.1).generate(int(1e5))
-    >>> filt = fnc.filtering.LMSFilter(n_filter, 0, 1)
+    >>> filt = fnc.filtering.LMSFilter(1, n_filter, 0)
     >>> filt.condition(witness, target)
     >>> prediction = filt.apply(witness, target) # check on the data used for conditioning
     >>> residual_rms = fnc.evaluation.rms(target-prediction)
@@ -86,14 +86,14 @@ class LMSFilter(FilterBase):
     @handle_from_dict
     def __init__(
         self,
+        n_channel: int,
         n_filter: int,
         idx_target: int,
-        n_channel: int = 1,
         normalized: bool = True,
         step_scale: float = 0.1,
         coefficient_clipping: float = np.nan,
     ):
-        super().__init__(n_filter, idx_target, n_channel)
+        super().__init__(n_channel, n_filter, idx_target)
         self.normalized = normalized
         self.step_scale = step_scale
         self.coefficient_clipping = coefficient_clipping

--- a/src/franc/filtering/polylms.py
+++ b/src/franc/filtering/polylms.py
@@ -96,7 +96,7 @@ class PolynomialLMSFilter(FilterBase):
     >>> import franc as fnc
     >>> n_filter = 128
     >>> witness, target = fnc.evaluation.TestDataGenerator(0.1).generate(int(1e5))
-    >>> filt = fnc.filtering.PolynomialLMSFilter(n_filter, 0, 1, step_scale=0.1, order=2, coefficient_clipping=4)
+    >>> filt = fnc.filtering.PolynomialLMSFilter(1, n_filter, 0, step_scale=0.1, order=2, coefficient_clipping=4)
     >>> filt.condition(witness, target)
     >>> prediction = filt.apply(witness, target) # check on the data used for conditioning
     >>> residual_rms = fnc.evaluation.rms((target-prediction)[1000:])
@@ -117,15 +117,15 @@ class PolynomialLMSFilter(FilterBase):
     @handle_from_dict
     def __init__(
         self,
+        n_channel: int,
         n_filter: int,
         idx_target: int,
-        n_channel: int = 1,
         normalized: bool = True,
         step_scale: float = 0.5,
         coefficient_clipping: float = np.nan,
         order: int = 1,
     ):
-        super().__init__(n_filter, idx_target, n_channel)
+        super().__init__(n_channel, n_filter, idx_target)
         self.normalized = normalized
         self.step_scale = step_scale
         self.coefficient_clipping = coefficient_clipping

--- a/src/franc/filtering/uwf.py
+++ b/src/franc/filtering/uwf.py
@@ -25,7 +25,7 @@ class UpdatingWienerFilter(FilterBase):
     >>> import franc as fnc
     >>> n_filter = 128
     >>> witness, target = fnc.evaluation.TestDataGenerator(0.1).generate(int(1e5))
-    >>> filt = fnc.filtering.UpdatingWienerFilter(n_filter, 0, 1, context_pre=20*n_filter, context_post=20*n_filter)
+    >>> filt = fnc.filtering.UpdatingWienerFilter(1, n_filter, 0, context_pre=20*n_filter, context_post=20*n_filter)
     >>> prediction = filt.apply(witness, target) # check on the data used for conditioning
     >>> residual_rms = fnc.evaluation.rms(target-prediction)
     >>> residual_rms > 0.05 and residual_rms < 0.15 # the expected RMS in this test scenario is 0.1
@@ -42,13 +42,13 @@ class UpdatingWienerFilter(FilterBase):
     @handle_from_dict
     def __init__(
         self,
+        n_channel: int,
         n_filter: int,
         idx_target: int,
-        n_channel: int = 1,
         context_pre: int = 0,
         context_post: int = 0,
     ):
-        super().__init__(n_filter, idx_target, n_channel)
+        super().__init__(n_channel, n_filter, idx_target)
         self.context_pre = context_pre
         self.context_post = context_post
 

--- a/src/franc/filtering/wf.py
+++ b/src/franc/filtering/wf.py
@@ -140,7 +140,7 @@ class WienerFilter(FilterBase):
     >>> import franc as fnc
     >>> n_filter = 128
     >>> witness, target = fnc.evaluation.TestDataGenerator(0.1).generate(int(1e5))
-    >>> filt = fnc.filtering.WienerFilter(n_filter, 0, 1)
+    >>> filt = fnc.filtering.WienerFilter(1, n_filter, 0)
     >>> _coefficients, full_rank = filt.condition(witness, target)
     >>> full_rank
     True
@@ -158,11 +158,11 @@ class WienerFilter(FilterBase):
     @handle_from_dict
     def __init__(
         self,
+        n_channel: int,
         n_filter: int,
         idx_target: int,
-        n_channel: int = 1,
     ):
-        super().__init__(n_filter, idx_target, n_channel)
+        super().__init__(n_channel, n_filter, idx_target)
         self.requires_apply_target = False
 
     def condition_multi_sequence(

--- a/src/meson.build
+++ b/src/meson.build
@@ -24,6 +24,7 @@ python_sources = [
   'franc/evaluation/dataset.py',
   'franc/evaluation/metrics.py',
   'franc/evaluation/evaluation.py',
+  'franc/evaluation/filter_interface.py',
   'franc/evaluation/report_generation.py',
 ]
 

--- a/testing/filtering/test_external_spicypy_wf.py
+++ b/testing/filtering/test_external_spicypy_wf.py
@@ -6,7 +6,9 @@ import franc
 from .test_filters import TestFilter
 
 
-class TestSpicypyWienerFilter(TestFilter.TestFilter):
+class TestSpicypyWienerFilter(
+    TestFilter.TestFilter[franc.external.SpicypyWienerFilter]
+):
     """Tests for the spicypy WF implementation"""
 
     __test__ = True

--- a/testing/filtering/test_lms.py
+++ b/testing/filtering/test_lms.py
@@ -1,15 +1,18 @@
 """Tests for filtering.LMSFilter"""
 
+from typing import Iterable
+
 import numpy as np
 
 import franc as fnc
+from franc.filtering.lms import LMSFilter
 
 from .test_filters import TestFilter
 
 RNG_SEED = 113510
 
 
-class TestLMSFilter(TestFilter.TestFilter):
+class TestLMSFilter(TestFilter.TestFilter[LMSFilter]):
     """tests for the LeastMeanSquares filter implementation"""
 
     __test__ = True
@@ -24,13 +27,22 @@ class TestLMSFilter(TestFilter.TestFilter):
         ]
         self.set_target(fnc.filtering.LMSFilter, test_configurations)
 
+    # mark return type of instantiate_filters correctly
+    def instantiate_filters(
+        self, n_channel=1, n_filter=128, idx_target=0
+    ) -> Iterable[LMSFilter]:
+        return_value: Iterable[LMSFilter] = super().instantiate_filters(
+            n_channel, n_filter, idx_target
+        )
+        return return_value
+
     def test_update_state_setting(self):
         """check that the filter reaches a WF-Like performance on a simple static test case"""
         witness, target = fnc.evaluation.TestDataGenerator(
             [0.1] * 2, rng_seed=RNG_SEED
         ).generate(int(2e4))
 
-        for filt in self.instantiate_filters(n_filter=32, n_channel=2):
+        for filt in self.instantiate_filters(n_channel=2, n_filter=32):
             # check for no changes when False
             filt.apply(witness, target, update_state=False)
             self.assertTrue(bool(np.all(filt.filter_state == 0)))

--- a/testing/filtering/test_polylms.py
+++ b/testing/filtering/test_polylms.py
@@ -7,7 +7,7 @@ from .test_lms import TestLMSFilter
 
 
 class TestPolynomialLMSFilter(TestLMSFilter):
-    """tests for the polynomial vaiant of a LeastMeanSquares filter implementation"""
+    """tests for the polynomial variant of a LeastMeanSquares filter implementation"""
 
     __test__ = True
 

--- a/testing/filtering/test_uwf.py
+++ b/testing/filtering/test_uwf.py
@@ -1,11 +1,12 @@
 """Tests for TestUpdatingWienerFilter"""
 
 import franc as fnc
+from franc.filtering.uwf import UpdatingWienerFilter
 
 from .test_filters import TestFilter
 
 
-class TestUpdatingWienerFilter(TestFilter.TestFilter):
+class TestUpdatingWienerFilter(TestFilter.TestFilter[UpdatingWienerFilter]):
     """Test cases for the UWF"""
 
     __test__ = True
@@ -22,7 +23,7 @@ class TestUpdatingWienerFilter(TestFilter.TestFilter):
         n_filter = 128
         witness, target = fnc.evaluation.TestDataGenerator([0.1]).generate(int(1e4))
 
-        for filt in self.instantiate_filters(n_filter, n_channel=2):
+        for filt in self.instantiate_filters(n_channel=2, n_filter=n_filter):
             self.assertWarns(RuntimeWarning, filt.condition, witness, target)
 
     def test_non_full_rank_warning(self):
@@ -34,7 +35,7 @@ class TestUpdatingWienerFilter(TestFilter.TestFilter):
         # using two identical input datasets produces non-full-rank autocorrelation matrices
         witness = [witness[0]] * n_channel
 
-        for filt in self.instantiate_filters(n_filter, n_channel=n_channel):
+        for filt in self.instantiate_filters(n_channel=n_channel, n_filter=n_filter):
             self.assertWarns(RuntimeWarning, filt.apply, witness, target)
 
     def test_acceptance_of_minimum_input_length_different_context_length(self):
@@ -43,10 +44,14 @@ class TestUpdatingWienerFilter(TestFilter.TestFilter):
         witness, target = fnc.evaluation.TestDataGenerator([0.1]).generate(n_filter * 2)
 
         for context_len in [0, 10000]:
-            filt = self.target_filter(n_filter, 0, 1, context_pre=context_len)
+            filt = self.target_filter(
+                n_channel=1, n_filter=n_filter, idx_target=0, context_pre=context_len
+            )
             pred = filt.apply(witness, target)
             self.assertEqual(len(pred), len(target))
 
-            filt = self.target_filter(n_filter, 0, 1, context_post=context_len)
+            filt = self.target_filter(
+                n_channel=1, n_filter=n_filter, idx_target=0, context_post=context_len
+            )
             pred = filt.apply(witness, target)
             self.assertEqual(len(pred), len(target))

--- a/testing/filtering/test_wf.py
+++ b/testing/filtering/test_wf.py
@@ -1,11 +1,12 @@
 """Tests for WienerFilter"""
 
 import franc as fnc
+from franc.filtering.wf import WienerFilter
 
 from .test_filters import TestFilter
 
 
-class TestWienerFilter(TestFilter.TestFilter):
+class TestWienerFilter(TestFilter.TestFilter[WienerFilter]):
     """Tests for the WF"""
 
     __test__ = True
@@ -22,7 +23,7 @@ class TestWienerFilter(TestFilter.TestFilter):
         # using two identical input datasets produces non-full-rank autocorrelation matrices
         witness = [witness[0], witness[0]]
 
-        for filt in self.instantiate_filters(n_filter, n_channel=2):
+        for filt in self.instantiate_filters(n_channel=2, n_filter=n_filter):
             self.assertWarns(RuntimeWarning, filt.condition, witness, target)
 
     def test_no_target_for_apply(self):
@@ -30,6 +31,6 @@ class TestWienerFilter(TestFilter.TestFilter):
         n_filter = 128
         witness, target = fnc.evaluation.TestDataGenerator(0.1).generate(n_filter * 2)
 
-        for filt in self.instantiate_filters(n_filter):
+        for filt in self.instantiate_filters(n_channel=1, n_filter=n_filter):
             filt.condition(witness, target)
             filt.apply(witness)

--- a/tooling/profiling/profile.py
+++ b/tooling/profiling/profile.py
@@ -114,23 +114,24 @@ filter_configuration_strings = filter_configs_to_str(FILTER_CONFIGURATIONS)
 
 def run_profiling(config, n_samples, n_filter, n_channel, idx_target=0):
     """execute a profiling run for specific configuration for a list of filter configurations
-    to unwrap config list and replace irrelevant restuls with nans
+    to unwrap config list and replace irrelevant results with NaNs
 
     :param config: filter configurations as a list of (filter_instance, additional_filter_params, clear_conditioning_runtime)
                     setting clear_conditioning_runtime to True will set the conditioning runtime to np.nan
     :params n_samples, n_filter, n_channel, idx_target: passed on to franc.measure_runtime()
     """
-    filters = map(lambda x: x[0], config)
-    additional_settings = map(lambda x: x[1], config)
+    filters = list(map(lambda x: x[0], config))
+    additional_settings = list(map(lambda x: x[1], config))
     skip_conditioning = list(map(lambda x: x[2], config))
 
     results = fnc.evaluation.measure_runtime(
         filters,
-        n_samples,
-        n_filter=n_filter,
+        n_samples=n_samples,
         n_channel=n_channel,
-        additional_filter_settings=additional_settings,
+        n_filter=n_filter,
         idx_target=idx_target,
+        additional_filter_settings=additional_settings,
+        repititions=1,
     )
     results = np.array(results)
     results[0, skip_conditioning] = np.nan


### PR DESCRIPTION
To fulfill the requirements set by `EvaluationRun`, only the `n_channel` parameter is relevant. So this PR moves the `n_channel` parameter to be the first one for `FilterBase` and all child classes. It then creates a parent class for `FilterBase` that contains all functionality but the additional two init arguments `n_filter` and `idx_target`.