### PR TITLE
Remove duplicate texts from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,52 +10,13 @@ The techniques for the prediction of a correlated signal component from witness 
 
 [Documentation](https://franc.readthedocs.io/en/latest/)
 
-## Filtering methods
-
-Static:
-
-* Wiener Filter (WF)
-
-Adaptive
-
-* Updating Wiener Fitler (UWF)
-* Least-Mean-Squares Filter (LMS)
-
-Non-Linear:
-
-* Experimental non-linear LMS Filter variant (PolynomialLMS)
-
 ## Install
 
 From pypi: `pip install franc`
 
 From repository: `pip install .`
 
-From repository (editable): `make ie`
-
-## Minimal example
-
-```python
->>> import franc as fnc
->>>
->>> # generate data
->>> n_channel = 2
->>> witness, target = fnc.eval.TestDataGenerator([0.1]*n_channel).generate(int(1e5))
->>>
->>> # instantiate the filter and apply it
->>> filt = fnc.filt.LMSFilter(n_filter=128, idx_target=0, n_channel=n_channel)
->>> filt.condition(witness, target)
->>> prediction = filt.apply(witness, target) # check on the data used for conditioning
->>>
->>> # success
->>> fnc.eval.rms(target-prediction) / fnc.eval.rms(prediction)
-0.08221177645361015
-```
-
-## Terminology
-
-* Witness signal w: One or multiple sensors that are used to make a prediction
-* Target signal s: The goal for the prediction
+From repository (editable): `pip install meson-python ninja && make ie`
 
 ## License
 


### PR DESCRIPTION
These texts are already in the documentation. Having two placec where they need to be udpated and kept in sync creates work that is not worth the effort.