### PR TITLE
pin the python version of the publishing action to 3.13

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: "3.13"
 
       - name: Build release distributions
         run: |
@@ -47,7 +47,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: "3.13"
 
       - name: Retrieve release distributions
         uses: actions/download-artifact@v4


### PR DESCRIPTION
by default it takes the latest release (3.14 at time of writing) due to spicipy not supporting the latest release yet, this does not work