### PR TITLE
make spicypy dependency optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
   "icecream",
   "numba",
   "psutil ~= 5.8",
-  "spicypy ~= 0.9",
 ]
 classifiers = [
   "Programming Language :: Python :: 3",
@@ -45,6 +44,7 @@ dev = [
   "pytest >= 7.4",
   "sphinx-autoapi~=3.3",
   "sphinx-rtd-theme",
+  "spicypy ~= 0.9",
 ]
 
 [project.urls]

--- a/src/franc/external/__init__.py
+++ b/src/franc/external/__init__.py
@@ -1,5 +1,10 @@
 """Wrappers for other implementations of filtering techniques."""
 
-from .spicypy_wf import SpicypyWienerFilter
+__all__ = []
 
-__all__ = ["SpicypyWienerFilter"]
+try:
+    from .spicypy_wf import SpicypyWienerFilter
+
+    __all__.append("SpicypyWienerFilter")
+except ImportError:
+    print("To use spicipy filters, install spicypy")


### PR DESCRIPTION
installing spicypy on windows is not trivial
this makes usage of this library a lot simpler in 99% of usecases