### PR TITLE
fix autoapi generation on readthedocs

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,4 @@
 sphinx~=7.1.2
 sphinx-autoapi~=3.3
 sphinx-rtd-theme
+astroid<4


### PR DESCRIPTION
Local build works, but not on RTD.
This follows the suggestion in https://github.com/readthedocs/readthedocs.org/issues/11975